### PR TITLE
Add TypeScript types declaration file (resolve #2)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ declare module 'stormdb' {
     class StormDBClass {
       constructor(engine: StormDB.LocalFileEngine, options?: object);
 
+      static browserEngine(path: string, options?: object): BrowserEngine;
       static localFileEngine(path: string, options?: object): LocalFileEngine;
       default(defaultValue: object): StormDBClass;
       length(): StormDBClass;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+declare module 'stormdb' {
+  namespace StormDB {
+    class StormDBClass {
+      constructor(engine: StormDB.LocalFileEngine, options?: object);
+
+      static localFileEngine(path: string, options?: object): LocalFileEngine;
+      default(defaultValue: object): StormDBClass;
+      length(): StormDBClass;
+      delete(): void;
+      push(value: any): void;
+      get(value: any): StormDBClass;
+      set(key: any, value: any): StormDBClass;
+      value(): any;
+      setValue(value: any, pointers: any[], setRecursively?: boolean): void;
+      save(): Promise<void> | null;
+    }
+
+    class Base {
+      serialize<T>(data: T): (data: T) => void;
+      deserialize<T>(data: T): (data: T) => void;
+    }
+
+    class LocalFileEngine extends Base {
+      constructor(path: string, options?: object);
+      init(): object;
+      read(): object;
+      write(data: any): Promise<void> | null;
+    }
+  }
+
+  export default StormDB.StormDBClass;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,9 +11,9 @@ declare module 'stormdb' {
       push(value: any): void;
       get(value: any): StormDBClass;
       set(key: any, value: any): StormDBClass;
-      map(func: any): StormDBClass;
-      sort(func: any): StormDBClass;
-      filter(func: any): StormDBClass;
+      map<T>(func: (value: any, index?: number, array?: any[]) => T): StormDBClass;
+      sort<T>(func: (a: T, b: T) => number): StormDBClass;
+      filter<T, S extends T>(func: (value: T, index?: number, array?: T[]) => value is S): StormDBClass;
       value(): any;
       setValue(value: any, pointers: any[], setRecursively?: boolean): void;
       save(): Promise<void> | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,17 +10,22 @@ declare module 'stormdb' {
       push(value: any): void;
       get(value: any): StormDBClass;
       set(key: any, value: any): StormDBClass;
+      map(func: any): StormDBClass;
+      sort(func: any): StormDBClass;
+      filter(func: any): StormDBClass;
       value(): any;
       setValue(value: any, pointers: any[], setRecursively?: boolean): void;
       save(): Promise<void> | null;
     }
 
-    class Base {
-      serialize<T>(data: T): (data: T) => void;
-      deserialize<T>(data: T): (data: T) => void;
+    class LocalFileEngine {
+      constructor(path: string, options?: object);
+      init(): object;
+      read(): object;
+      write(data: any): Promise<void> | null;
     }
 
-    class LocalFileEngine extends Base {
+    class BrowserEngine {
       constructor(path: string, options?: object);
       init(): object;
       read(): object;


### PR DESCRIPTION
Here is the file for TS developers. :fireworks: 

...So code written in TypeScript using this library needs to be written a little differently than in the code sample currently in the 'Usage' section of the Readme:

```ts
// Using 'require' loses all type information, making TS redundant
import StormDB from 'stormdb';

// This is the JavaScript approach depicted in the Readme
const engine = new StormDB.localFileEngine("./db.stormdb");
const db = StormDB(engine);

// And here is the TypeScript approach, necessary because 'engine' throws an error
// that says "Only a void function can be called with the 'new' keyword [ts(2350)]",
// while 'db' throws an error that the StormDB class needs to be invoked (called with 'new').
const engine = StormDB.localFileEngine('./db.stormdb');
const db = new StormDB(engine);
```

I've had to hack on it a little bit since TypeScript doesn't accept the default export *and* non-default additional export in `index.js` (it either should be one single default exports or multiple non-default exports). `localFileEngine` is declared as a static method in the `StormDB` class, which returns the *class* of `LocalFileEngine` with its respective methods. 

I hope the hacky approach is ok. If you have any queries, let me know.