### PR TITLE
Types declaration file (revised)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,38 +1,37 @@
 declare module 'stormdb' {
-  namespace StormDB {
-    class StormDBClass {
-      constructor(engine: StormDB.LocalFileEngine, options?: object);
+  class StormDB {
+    constructor(engine: LocalFileEngine, options?: object);
 
-      static browserEngine(path: string, options?: object): BrowserEngine;
-      static localFileEngine(path: string, options?: object): LocalFileEngine;
-      default(defaultValue: object): StormDBClass;
-      length(): StormDBClass;
-      delete(): void;
-      push(value: any): void;
-      get(value: any): StormDBClass;
-      set(key: any, value: any): StormDBClass;
-      map<T>(func: (value: any, index?: number, array?: any[]) => T): StormDBClass;
-      sort<T>(func: (a: T, b: T) => number): StormDBClass;
-      filter<T, S extends T>(func: (value: T, index?: number, array?: T[]) => value is S): StormDBClass;
-      value(): any;
-      setValue(value: any, pointers: any[], setRecursively?: boolean): void;
-      save(): Promise<void> | null;
-    }
+    static browserEngine: typeof BrowserEngine;
+    static localFileEngine: typeof LocalFileEngine;
 
-    class LocalFileEngine {
-      constructor(path: string, options?: object);
-      init(): object;
-      read(): object;
-      write(data: any): Promise<void> | null;
-    }
-
-    class BrowserEngine {
-      constructor(path: string, options?: object);
-      init(): object;
-      read(): object;
-      write(data: any): Promise<void> | null;
-    }
+    default(defaultValue: object): StormDB;
+    length(): StormDB;
+    delete(): void;
+    push(value: any): void;
+    get(value: any): StormDB;
+    set(key: any, value: any): StormDB;
+    map<T>(func: (value: any, index?: number, array?: any[]) => T): StormDB;
+    sort<T>(func: (a: T, b: T) => number): StormDB;
+    filter<T, S extends T>(func: (value: T, index?: number, array?: T[]) => value is S): StormDB;
+    value(): any;
+    setValue(value: any, pointers: any[], setRecursively?: boolean): void;
+    save(): Promise<void> | null;
   }
 
-  export default StormDB.StormDBClass;
+  class LocalFileEngine {
+    constructor(path: string, options?: object);
+    init(): object;
+    read(): object;
+    write(data: any): Promise<void> | null;
+  }
+
+  class BrowserEngine {
+    constructor(path: string, options?: object);
+    init(): object;
+    read(): object;
+    write(data: any): Promise<void> | null;
+  }
+
+  export = StormDB;
 }


### PR DESCRIPTION
#5  

`browserEngine` and `localFileEngine` can now be instantiated with the `new` keyword in a TypeScript file without any concerns.