### PR TITLE
Reduce

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -200,6 +200,21 @@ db.get("data").map(x => x ** 2);
 db.save();
 ```
 
+Reduce List, Finding Value of All Values in List Summed:
+
+```js
+// before = {'data': [1,2,3,4,5]}
+// after = {'data': 15}
+
+// find value of all numbers in list summed together
+db.get("data").reduce(
+  (accumulator, currentValue) => accumulator + currentValue
+);
+
+// save db
+db.save();
+```
+
 Leverage Serialize and Deserialize functions to encrypt and decrypt data:
 
 ```js

--- a/src/stormdb.js
+++ b/src/stormdb.js
@@ -78,6 +78,19 @@ class StormDB {
     return this;
   }
 
+  reduce(func) {
+    let list = this.value();
+
+    if (typeof func !== "function")
+      throw new Error("You can only pass functions to .reduce().");
+    if (!Array.isArray(list)) throw new Error("You can only reduce lists.");
+
+    let reducedValue = list.reduce(func);
+    this.set(reducedValue);
+
+    return this;
+  }
+
   get(value) {
     let clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     clone.pointers = [...clone.pointers, value];

--- a/tests/CRUD.js
+++ b/tests/CRUD.js
@@ -245,6 +245,46 @@ describe("StormDB", function() {
     });
   });
 
+  describe(".reduce()", function() {
+    it("should reduce array", function() {
+      const engine = new StormDB.localFileEngine(exampleDBPath);
+      const db = new StormDB(engine);
+
+      db.get("test-list").reduce(
+        (accumulator, currentValue) => accumulator + currentValue
+      );
+
+      let updatedList = db.get("test-list").value();
+      assert.deepEqual(updatedList, 15);
+    });
+
+    it("should refuse to reduce a non-array", function() {
+      const engine = new StormDB.localFileEngine(exampleDBPath);
+      const db = new StormDB(engine);
+
+      const tryReduce = () => {
+        db.get("test-string").reduce(
+          (accumulator, currentValue) => accumulator + currentValue
+        );
+      };
+
+      // should refuse to reduce string and therefore should raise an exception
+      assert.throws(tryReduce, Error);
+    });
+
+    it("should refuse to reduce not using function or undefined", function() {
+      const engine = new StormDB.localFileEngine(exampleDBPath);
+      const db = new StormDB(engine);
+
+      const tryReduce = () => {
+        db.get("test-list").reduce("non-function");
+      };
+
+      // should refuse to reduce with non-function and therefore should raise an exception
+      assert.throws(tryReduce, Error);
+    });
+  });
+
   describe(".filter()", function() {
     it("should filter array", function() {
       const engine = new StormDB.localFileEngine(exampleDBPath);


### PR DESCRIPTION
Added `.reduce()` to StormDB with similar behaviour to `.map()` etc.

- Reduces an array in the database using the provided function, then replaces the array in the database with the reduced value, returning the StormDB object.