### PR TITLE
get() function error handler and consistent indentation

### DIFF
--- a/src/stormdb.js
+++ b/src/stormdb.js
@@ -7,10 +7,10 @@ class StormDB {
   }
 
   default(defaultValue) {
-    let stateEmpty =
-      Object.keys(this.state).length === 0 && this.state.constructor === Object;
+    let stateEmpty = Object.keys(this.state).length === 0 && this.state.constructor === Object;
 
-    if (stateEmpty) this.state = defaultValue;
+    if (stateEmpty)
+      this.state = defaultValue;
 
     return this;
   }
@@ -33,7 +33,8 @@ class StormDB {
   push(value) {
     let list = this.value();
 
-    if (!Array.isArray(list)) throw new Error("You can only push to lists.");
+    if (!Array.isArray(list))
+      throw new Error("You can only push to lists.");
 
     list.push(value);
     this.set(list);
@@ -46,7 +47,8 @@ class StormDB {
 
     if (typeof func !== "function")
       throw new Error("You can only pass functions to .map().");
-    if (!Array.isArray(list)) throw new Error("You can only map lists.");
+    if (!Array.isArray(list))
+      throw new Error("You can only map lists.");
 
     list = list.map(func);
     this.set(list);
@@ -59,7 +61,8 @@ class StormDB {
 
     if (typeof func !== "function")
       throw new Error("You can only pass functions to .filter().");
-    if (!Array.isArray(list)) throw new Error("You can only filter lists.");
+    if (!Array.isArray(list))
+      throw new Error("You can only filter lists.");
 
     list = list.filter(func);
     this.set(list);
@@ -72,7 +75,8 @@ class StormDB {
 
     if (typeof func !== "function" && func !== undefined)
       throw new Error("You can only pass functions or nothing to .sort().");
-    if (!Array.isArray(list)) throw new Error("You can only sort lists.");
+    if (!Array.isArray(list))
+      throw new Error("You can only sort lists.");
 
     list.sort(func);
     this.set(list);
@@ -85,7 +89,8 @@ class StormDB {
 
     if (typeof func !== "function")
       throw new Error("You can only pass functions to .reduce().");
-    if (!Array.isArray(list)) throw new Error("You can only reduce lists.");
+    if (!Array.isArray(list))
+      throw new Error("You can only reduce lists.");
 
     let reducedValue = list.reduce(func);
     this.set(reducedValue);
@@ -94,60 +99,64 @@ class StormDB {
   }
 
   get(value) {
-    let clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
-    clone.pointers = [...clone.pointers, value];
-    return clone;
-  }
+    if (Object.hasOwnProperty(value)) {
+      let clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+      clone.pointers = [...clone.pointers, value];
+      return clone;
+    } else
+      throw new Error("Key does not exist.");
 
-  set(key, value) {
-    if (value === undefined) {
-      this.setValue(key);
-    } else {
-      let extraPointers;
-      if (typeof key === "string") extraPointers = key.split(".");
-      else extraPointers = [key];
-
-      this.setValue(value, extraPointers);
-    }
-    return this;
-  }
-
-  value() {
-    let data = this.state;
-    for (let i = 0; i < this.pointers.length; i++) {
-      data = data[this.pointers[i]];
-    }
-
-    return data;
-  }
-
-  setValue(value, pointers = [], setrecursively = true) {
-    let depth = 0;
-
-    pointers = [...this.pointers, ...pointers];
-
-    const func = (a, b) => {
-      depth += 1;
-
-      let finalLevel = depth === pointers.length;
-      if (setrecursively && typeof a[b] === "undefined" && !finalLevel) {
-        a[b] = {};
-        return a[b];
-      }
-
-      if (finalLevel) {
-        a[b] = value;
-        return value;
+    set(key, value) {
+      if (value === undefined) {
+        this.setValue(key);
       } else {
-        return a[b];
+        let extraPointers;
+        if (typeof key === "string")
+          extraPointers = key.split(".");
+        else
+          extraPointers = [key];
+
+        this.setValue(value, extraPointers);
       }
-    };
-    pointers.reduce(func, this.state);
+      return this;
+    }
+
+    value() {
+      let data = this.state;
+      for (let i = 0; i < this.pointers.length; i++) {
+        data = data[this.pointers[i]];
+      }
+
+      return data;
+    }
+
+    setValue(value, pointers = [], setrecursively = true) {
+      let depth = 0;
+
+      pointers = [...this.pointers, ...pointers];
+
+      const func = (a, b) => {
+        depth += 1;
+
+        let finalLevel = depth === pointers.length;
+        if (setrecursively && typeof a[b] === "undefined" && !finalLevel) {
+          a[b] = {};
+          return a[b];
+        }
+
+        if (finalLevel) {
+          a[b] = value;
+          return value;
+        } else {
+          return a[b];
+        }
+      };
+      pointers.reduce(func, this.state);
+    }
+
+    save() {
+      return this.engine.write(this.state);
+    }
   }
 
-  save() {
-    return this.engine.write(this.state);
-  }
-}
-
-module.exports = StormDB;
+  module.exports = StormDB;

--- a/src/stormdb.js
+++ b/src/stormdb.js
@@ -10,7 +10,7 @@ class StormDB {
     let stateEmpty = Object.keys(this.state).length === 0 && this.state.constructor === Object;
 
     if (stateEmpty)
-      this.state = defaultValue;
+    this.state = defaultValue;
 
     return this;
   }
@@ -34,7 +34,7 @@ class StormDB {
     let list = this.value();
 
     if (!Array.isArray(list))
-      throw new Error("You can only push to lists.");
+    throw new Error("You can only push to lists.");
 
     list.push(value);
     this.set(list);
@@ -46,9 +46,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function")
-      throw new Error("You can only pass functions to .map().");
+    throw new Error("You can only pass functions to .map().");
     if (!Array.isArray(list))
-      throw new Error("You can only map lists.");
+    throw new Error("You can only map lists.");
 
     list = list.map(func);
     this.set(list);
@@ -60,9 +60,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function")
-      throw new Error("You can only pass functions to .filter().");
+    throw new Error("You can only pass functions to .filter().");
     if (!Array.isArray(list))
-      throw new Error("You can only filter lists.");
+    throw new Error("You can only filter lists.");
 
     list = list.filter(func);
     this.set(list);
@@ -74,9 +74,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function" && func !== undefined)
-      throw new Error("You can only pass functions or nothing to .sort().");
+    throw new Error("You can only pass functions or nothing to .sort().");
     if (!Array.isArray(list))
-      throw new Error("You can only sort lists.");
+    throw new Error("You can only sort lists.");
 
     list.sort(func);
     this.set(list);
@@ -88,9 +88,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function")
-      throw new Error("You can only pass functions to .reduce().");
+    throw new Error("You can only pass functions to .reduce().");
     if (!Array.isArray(list))
-      throw new Error("You can only reduce lists.");
+    throw new Error("You can only reduce lists.");
 
     let reducedValue = list.reduce(func);
     this.set(reducedValue);
@@ -104,59 +104,60 @@ class StormDB {
       clone.pointers = [...clone.pointers, value];
       return clone;
     } else
-      throw new Error("Key does not exist.");
-
-    set(key, value) {
-      if (value === undefined) {
-        this.setValue(key);
-      } else {
-        let extraPointers;
-        if (typeof key === "string")
-          extraPointers = key.split(".");
-        else
-          extraPointers = [key];
-
-        this.setValue(value, extraPointers);
-      }
-      return this;
-    }
-
-    value() {
-      let data = this.state;
-      for (let i = 0; i < this.pointers.length; i++) {
-        data = data[this.pointers[i]];
-      }
-
-      return data;
-    }
-
-    setValue(value, pointers = [], setrecursively = true) {
-      let depth = 0;
-
-      pointers = [...this.pointers, ...pointers];
-
-      const func = (a, b) => {
-        depth += 1;
-
-        let finalLevel = depth === pointers.length;
-        if (setrecursively && typeof a[b] === "undefined" && !finalLevel) {
-          a[b] = {};
-          return a[b];
-        }
-
-        if (finalLevel) {
-          a[b] = value;
-          return value;
-        } else {
-          return a[b];
-        }
-      };
-      pointers.reduce(func, this.state);
-    }
-
-    save() {
-      return this.engine.write(this.state);
-    }
+    throw new Error("Key does not exist.");
   }
 
-  module.exports = StormDB;
+  set(key, value) {
+    if (value === undefined) {
+      this.setValue(key);
+    } else {
+      let extraPointers;
+      if (typeof key === "string")
+      extraPointers = key.split(".");
+      else
+      extraPointers = [key];
+
+      this.setValue(value, extraPointers);
+    }
+    return this;
+  }
+
+  value() {
+    let data = this.state;
+    for (let i = 0; i < this.pointers.length; i++) {
+      data = data[this.pointers[i]];
+    }
+
+    return data;
+  }
+
+  setValue(value, pointers = [], setrecursively = true) {
+    let depth = 0;
+
+    pointers = [...this.pointers, ...pointers];
+
+    const func = (a, b) => {
+      depth += 1;
+
+      let finalLevel = depth === pointers.length;
+      if (setrecursively && typeof a[b] === "undefined" && !finalLevel) {
+        a[b] = {};
+        return a[b];
+      }
+
+      if (finalLevel) {
+        a[b] = value;
+        return value;
+      } else {
+        return a[b];
+      }
+    };
+    pointers.reduce(func, this.state);
+  }
+
+  save() {
+    return this.engine.write(this.state);
+  }
+}
+
+module.exports = StormDB;

--- a/src/stormdb.js
+++ b/src/stormdb.js
@@ -34,7 +34,7 @@ class StormDB {
     let list = this.value();
 
     if (!Array.isArray(list))
-    throw new Error("You can only push to lists.");
+      throw new Error("You can only push to lists.");
 
     list.push(value);
     this.set(list);
@@ -46,9 +46,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function")
-    throw new Error("You can only pass functions to .map().");
+      throw new Error("You can only pass functions to .map().");
     if (!Array.isArray(list))
-    throw new Error("You can only map lists.");
+      throw new Error("You can only map lists.");
 
     list = list.map(func);
     this.set(list);
@@ -60,9 +60,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function")
-    throw new Error("You can only pass functions to .filter().");
+      throw new Error("You can only pass functions to .filter().");
     if (!Array.isArray(list))
-    throw new Error("You can only filter lists.");
+      throw new Error("You can only filter lists.");
 
     list = list.filter(func);
     this.set(list);
@@ -74,9 +74,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function" && func !== undefined)
-    throw new Error("You can only pass functions or nothing to .sort().");
+      throw new Error("You can only pass functions or nothing to .sort().");
     if (!Array.isArray(list))
-    throw new Error("You can only sort lists.");
+      throw new Error("You can only sort lists.");
 
     list.sort(func);
     this.set(list);
@@ -88,9 +88,9 @@ class StormDB {
     let list = this.value();
 
     if (typeof func !== "function")
-    throw new Error("You can only pass functions to .reduce().");
+      throw new Error("You can only pass functions to .reduce().");
     if (!Array.isArray(list))
-    throw new Error("You can only reduce lists.");
+      throw new Error("You can only reduce lists.");
 
     let reducedValue = list.reduce(func);
     this.set(reducedValue);
@@ -113,9 +113,9 @@ class StormDB {
     } else {
       let extraPointers;
       if (typeof key === "string")
-      extraPointers = key.split(".");
+        extraPointers = key.split(".");
       else
-      extraPointers = [key];
+        extraPointers = [key];
 
       this.setValue(value, extraPointers);
     }


### PR DESCRIPTION
See issue #18 

I fixed the indentation and the one-line conditional loops, some of them were all on 1 line and some where on 2 lines, I put them all on 2 lines for readability and consistency's sake. I also implemented the error handler for the get() function on the issue that's linked to this one.